### PR TITLE
Add some folder and permissions  API calls

### DIFF
--- a/grafana_api/grafana_face.py
+++ b/grafana_api/grafana_face.py
@@ -590,6 +590,19 @@ class GrafanaFace:
             json_data['uid'] = uid
         return self.api.POST('/folders', json=json_data)
 
+    # folder permission
+
+    def update_folder_permissions(self, uid, items):
+        """
+        Updates permissions for a folder.
+
+        This operation will remove existing permissions if they’re not included in the request.
+
+        :param uid: Folder uid
+        """
+        # TODO really relevant to return something?
+        return self.api.POST('/folders/%s/permissions' % uid, json=dict(items=items))
+
     # api
 
     def get_api_keys(self):

--- a/grafana_api/grafana_face.py
+++ b/grafana_api/grafana_face.py
@@ -557,6 +557,14 @@ class GrafanaFace:
 
     # dashboard permission
 
+    def get_dashboard_permissions(self, dashboardId):
+        """
+        Gets all existing permissions for the dashboard with the given dashboardId.
+
+        :param dashboardId:
+        """
+        return self.api.GET('/dashboards/id/%s/permissions' % dashboardId)
+
     def update_dashboard_permissions(self, dashboardId, items):
         """
         Updates permissions for a dashboard.

--- a/grafana_api/grafana_face.py
+++ b/grafana_api/grafana_face.py
@@ -555,6 +555,19 @@ class GrafanaFace:
         r = self.api.GET(get_dashboards_tags_path)
         return r
 
+    # dashboard permission
+
+    def update_dashboard_permissions(self, dashboardId, items):
+        """
+        Updates permissions for a dashboard.
+
+        This operation will remove existing permissions if they’re not included in the request.
+
+        :param dashboardId: Dashboard id
+        """
+        # TODO really relevant to return something?
+        return self.api.POST('/dashboards/id/%s/permissions' % dashboardId, json=dict(items=items))
+
     # folder
 
     def create_folder(self, title, uid=None):

--- a/grafana_api/grafana_face.py
+++ b/grafana_api/grafana_face.py
@@ -555,6 +555,22 @@ class GrafanaFace:
         r = self.api.GET(get_dashboards_tags_path)
         return r
 
+    # folder
+
+    def create_folder(self, title, uid=None):
+        """
+        Creates a new folder.
+
+        :param title: The title of the folder.
+        :param uid: Optional unique identifier.
+        """
+        json_data = dict(title=title)
+        if uid is not None:
+            json_data['uid'] = uid
+        return self.api.POST('/folders', json=json_data)
+
+    # api
+
     def get_api_keys(self):
         """
 


### PR DESCRIPTION
Add
 * update_folder_permissions
 * get_dashboard_permissions
 * update_dashboard_permissions
 * create_folder

There is this TODO about the usefulness of return something from `update_dashboard_permissions` and `update_folder_permissions`. The success value is always the same, and if there was an error, it would raise anyway. But as the others API's call are always returning values, I followed the pattern.