### PR TITLE
Fix setup.py so that new 'api' module directory is included in package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,10 @@ setup(name='grafana_api',
       author='Andrew Prokhorenkov',
       author_email='andrew.prokhorenkov@gmail.com',
       license='MIT',
-      packages=['grafana_api'],
+      packages=[
+          'grafana_api',
+          'grafana_api.api'
+      ],
       install_requires=[
           'requests',
       ],


### PR DESCRIPTION
The newly released v0.3.1 package cannot actually be imported after installation:
```
>>> import grafana_api
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.6/site-packages/grafana_api-0.3.1-py3.6.egg/grafana_api/__init__.py", line 1, in <module>
    from .grafana_face import GrafanaFace
  File "/usr/local/lib/python3.6/site-packages/grafana_api-0.3.1-py3.6.egg/grafana_api/grafana_face.py", line 2, in <module>
    from .api import Base
ModuleNotFoundError: No module named 'grafana_api.api'
```

This is because the .api submodule is not actually included in the package. In order for it to be included, it needs to be explicitly listed in `setup.py`. This PR should address this.