### PR TITLE
Fix token based auth

### DIFF
--- a/grafana_api/grafana_api.py
+++ b/grafana_api/grafana_api.py
@@ -71,10 +71,10 @@ class GrafanaAPI:
         self.url = construct_api_url()
 
         self.s = requests.Session()
-        if isinstance(self.auth, tuple):
-            self.s.auth = TokenAuth(self.auth)
+        if not isinstance(self.auth, tuple):
+            self.auth = TokenAuth(self.auth)
         else:
-            self.s.auth = requests.auth.HTTPBasicAuth(*self.auth)
+            self.auth = requests.auth.HTTPBasicAuth(*self.auth)
 
     def __getattr__(self, item):
         def __request_runnner(url, json=None, headers=None):

--- a/test/test_grafana.py
+++ b/test/test_grafana.py
@@ -1,7 +1,9 @@
 import unittest
 from unittest.mock import patch, Mock
+import requests
 
 from grafana_api.grafana_face import GrafanaFace
+from grafana_api.grafana_api import TokenAuth
 
 
 class TestGrafanaAPI(unittest.TestCase):
@@ -16,8 +18,19 @@ class TestGrafanaAPI(unittest.TestCase):
   "orgId": 1,
   "isGrafanaAdmin": true
 }"""
-        cli = GrafanaFace(('admin', 'admin'), host='localhost', url_path_prefix='', protocol='https')
+        cli = GrafanaFace(('admin', 'admin'), host='localhost',
+                          url_path_prefix='', protocol='https')
         cli.users.find_user('test@test.com')
+
+    def test_grafana_api_basic_auth(self):
+        cli = GrafanaFace(('admin', 'admin'), host='localhost',
+                          url_path_prefix='', protocol='https')
+        self.assertTrue(isinstance(cli.api.auth, requests.auth.HTTPBasicAuth))
+
+    def test_grafana_api_token_auth(self):
+        cli = GrafanaFace('alongtoken012345etc', host='localhost',
+                          url_path_prefix='', protocol='https')
+        self.assertTrue(isinstance(cli.api.auth, TokenAuth))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
There seems to be 2 problems here:
1. it is setting self.s.auth instead of self.auth (__request_runner uses self.auth which is otherwise unset)
2. the logic seems to be the wrong way around (BasicAuth uses a tuple not the AuthToken)

With this fix the request works for me