### PR TITLE
Pass verify into requests.get to support unverified ssl

### DIFF
--- a/grafana_api/grafana_api.py
+++ b/grafana_api/grafana_api.py
@@ -46,8 +46,9 @@ class TokenAuth(requests.auth.AuthBase):
 
 
 class GrafanaAPI:
-    def __init__(self, auth, host='localhost', port=None, url_path_prefix='', protocol='http'):
+    def __init__(self, auth, host='localhost', port=None, url_path_prefix='', protocol='http', verify=True):
         self.auth = auth
+        self.verify = verify
         self.url_host = host
         self.url_port = port
         self.url_path_prefix = url_path_prefix
@@ -80,7 +81,7 @@ class GrafanaAPI:
         def __request_runnner(url, json=None, headers=None):
             __url = '%s%s' % (self.url, url)
             runner = getattr(self.s, item.lower())
-            r = runner(__url, json=json, headers=headers, auth=self.auth)
+            r = runner(__url, json=json, headers=headers, auth=self.auth, verify=self.verify)
 
             if 500 <= r.status_code < 600:
                 raise GrafanaServerError("Server Error {0}: {1}".format(r.status_code,

--- a/grafana_api/grafana_face.py
+++ b/grafana_api/grafana_face.py
@@ -3,8 +3,8 @@ from .api import Base
 
 
 class GrafanaFace:
-    def __init__(self, auth, host="localhost", port=None, url_path_prefix="", protocol="http"):
-        self.api = GrafanaAPI(auth, host=host, port=port, url_path_prefix=url_path_prefix, protocol=protocol)
+    def __init__(self, auth, host="localhost", port=None, url_path_prefix="", protocol="http", verify=True):
+        self.api = GrafanaAPI(auth, host=host, port=port, url_path_prefix=url_path_prefix, protocol=protocol, verify=verify)
 
     def __getattr__(self, item):
         for cls in Base.__subclasses__():

--- a/test/test_grafana.py
+++ b/test/test_grafana.py
@@ -4,6 +4,15 @@ from unittest.mock import patch, Mock
 from grafana_api.grafana_face import GrafanaFace
 
 
+class MockResponse:
+    def __init__(self, json_data, status_code):
+        self.json_data = json_data
+        self.status_code = status_code
+
+    def json(self):
+        return self.json_data
+
+
 class TestGrafanaAPI(unittest.TestCase):
     @patch('grafana_api.grafana_api.GrafanaAPI.__getattr__')
     def test_grafana_api(self, mock_get):
@@ -16,8 +25,24 @@ class TestGrafanaAPI(unittest.TestCase):
   "orgId": 1,
   "isGrafanaAdmin": true
 }"""
-        cli = GrafanaFace(('admin', 'admin'), host='localhost', url_path_prefix='', protocol='https')
+        cli = GrafanaFace(('admin', 'admin'), host='localhost',
+                          url_path_prefix='', protocol='https')
         cli.users.find_user('test@test.com')
+
+    def test_grafana_api_no_verify(self):
+        cli = GrafanaFace(('admin', 'admin'), host='localhost',
+                          url_path_prefix='', protocol='https', verify=False)
+        cli.api.s.get = Mock(name='get')
+        cli.api.s.get.return_value = MockResponse({
+  "email": "user@mygraf.com",
+  "name": "admin",
+  "login": "admin",
+  "theme": "light",
+  "orgId": 1,
+  "isGrafanaAdmin": True}, 200)
+
+        cli.users.find_user('test@test.com')
+        cli.api.s.get.assert_called_once_with('https://localhost/api/users/lookup?loginOrEmail=test@test.com', auth=('admin', 'admin'), headers=None, json=None, verify=False)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I need this for an internal site
