### PR TITLE
Fixed search_dashboards tag filter

### DIFF
--- a/grafana_api/api/search.py
+++ b/grafana_api/api/search.py
@@ -37,9 +37,6 @@ class Search(Base):
         if folder_ids:
             params.append('folderIds=%s' % folder_ids)
 
-        if tag:
-            params.append('tag=%s' % tag)
-
         if starred:
             params.append('starred=%s' % starred)
 


### PR DESCRIPTION
## Description

Fixed search_dashboards tag filter.

Tag was being added to param list twice and it broke http request to grafana api.

## Have you written tests?

- [ ] Yes
- [X] No

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
