### PR TITLE
Add timeout

### DIFF
--- a/grafana_api/grafana_api.py
+++ b/grafana_api/grafana_api.py
@@ -56,9 +56,11 @@ class GrafanaAPI:
         url_path_prefix="",
         protocol="http",
         verify=True,
+        timeout=5.0,
     ):
         self.auth = auth
         self.verify = verify
+        self.timeout = timeout
         self.url_host = host
         self.url_port = port
         self.url_path_prefix = url_path_prefix
@@ -92,7 +94,7 @@ class GrafanaAPI:
             __url = "%s%s" % (self.url, url)
             runner = getattr(self.s, item.lower())
             r = runner(
-                __url, json=json, headers=headers, auth=self.auth, verify=self.verify
+                __url, json=json, headers=headers, auth=self.auth, verify=self.verify, timeout=self.timeout
             )
             if 500 <= r.status_code < 600:
                 raise GrafanaServerError(

--- a/grafana_api/grafana_face.py
+++ b/grafana_api/grafana_face.py
@@ -24,6 +24,7 @@ class GrafanaFace:
         url_path_prefix="",
         protocol="http",
         verify=True,
+        timeout=5.0,
     ):
         self.api = GrafanaAPI(
             auth,
@@ -32,6 +33,7 @@ class GrafanaFace:
             url_path_prefix=url_path_prefix,
             protocol=protocol,
             verify=verify,
+            timeout=timeout,
         )
         self.admin = Admin(self.api)
         self.dashboard = Dashboard(self.api)

--- a/test/test_grafana.py
+++ b/test/test_grafana.py
@@ -67,7 +67,21 @@ class TestGrafanaAPI(unittest.TestCase):
             headers=None,
             json=None,
             verify=False,
+            timeout=5.0,
         )
+
+    def test_grafana_api_timeout(self):
+        cli = GrafanaFace(
+            ("admin", "admin"),
+            host="play.grafana.org",
+            url_path_prefix="",
+            protocol="https",
+            verify=False,
+            timeout=0.0001
+        )
+
+        with self.assertRaises(requests.exceptions.Timeout):
+            cli.folder.get_all_folders()
 
     def test_grafana_api_basic_auth(self):
         cli = GrafanaFace(


### PR DESCRIPTION
## Description

This adds a default timeout of 5s to all requests. It is considered a good practice for production systems, especially in the context of a web server flask-like.

Fixes #42 

## Have you written tests?

- [x] Yes
- [ ] No
