### PR TITLE
Added support for notification channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Work on API implementation still in progress.
 |---|---|
 | Admin | + |
 | Alerting | - |
+| Alerting Notification Channels | + |
 | Annotations | + |
 | Authentication | +- |
 | Dashboard | + |

--- a/grafana_api/api/__init__.py
+++ b/grafana_api/api/__init__.py
@@ -9,4 +9,5 @@ from .user import User, Users
 from .team import Teams
 from .annotations import Annotations
 from .snapshots import Snapshots
+from .notifications import Notifications
 

--- a/grafana_api/api/notifications.py
+++ b/grafana_api/api/notifications.py
@@ -84,7 +84,7 @@ class Notifications(Base):
         :return: result of deletion
         """
         delete_notification_by_uid_path = (
-            "alert-notifications/uid/%s" % notification_uid
+            "/alert-notifications/uid/%s" % notification_uid
         )
         return self.api.DELETE(delete_notification_by_uid_path)
 
@@ -95,5 +95,5 @@ class Notifications(Base):
         :param notification_id: notification channel id
         :return: result of deletion
         """
-        delete_notification_by_id_path = "alert-notifications/uid/%s" % notification_id
+        delete_notification_by_id_path = "/alert-notifications/%s" % notification_id
         return self.api.DELETE(delete_notification_by_id_path)

--- a/grafana_api/api/notifications.py
+++ b/grafana_api/api/notifications.py
@@ -7,39 +7,93 @@ class Notifications(Base):
         self.api = api
 
     def get_channels(self):
+        """
+        https://grafana.com/docs/grafana/latest/http_api/alerting_notification_channels/#get-all-notification-channels
+
+        :return: all notification channels that the authenticated user has permission to view
+        """
         get_channels_path = "/alert-notifications"
         return self.api.GET(get_channels_path)
 
     def lookup_channels(self):
+        """
+        https://grafana.com/docs/grafana/latest/http_api/alerting_notification_channels/#get-all-notification-channels-lookup
+
+        :return: all notification channels, but with less detailed information
+        """
         lookup_channels_path = "/alert-notifications/lookup"
         return self.api.GET(lookup_channels_path)
 
     def get_channel_by_uid(self, channel_uid):
+        """
+        https://grafana.com/docs/grafana/latest/http_api/alerting_notification_channels/#get-notification-channel-by-uid
+
+        :param channel_uid: notification channel uid
+        :return: notification channel for the given channel uid
+        """
         get_channel_by_uid_path = "/alert-notifications/uid/%s" % channel_uid
         return self.api.GET(get_channel_by_uid_path)
 
     def get_channel_by_id(self, channel_id):
+        """
+        https://grafana.com/docs/grafana/latest/http_api/alerting_notification_channels/#get-notification-channel-by-id
+
+        :param: notification channel id
+        :return: notification channel for the given channel id
+        """
         get_channel_by_id_path = "/alert-notifications/%s" % channel_id
         return self.api.GET(get_channel_by_id_path)
 
     def create_channel(self, channel):
+        """
+        https://grafana.com/docs/grafana/latest/http_api/alerting_notification_channels/#create-notification-channel
+
+        :param: channel to be created
+        :return: created channel
+        """
         create_channel_path = "/alert-notifications"
         return self.api.POST(create_channel_path, json=channel)
 
     def update_channel_by_uid(self, uid, channel):
+        """
+        https://grafana.com/docs/grafana/latest/http_api/alerting_notification_channels/#update-notification-channel-by-uid
+
+        :param uid: notification channel uid
+        :param channel: updated version of channel
+        :return: updated version of channel
+        """
         update_channel_by_uid_path = "/alert-notifications/uid/%s" % uid
         return self.api.PUT(update_channel_by_uid_path, json=channel)
 
     def update_channel_by_id(self, id, channel):
+        """
+        https://grafana.com/docs/grafana/latest/http_api/alerting_notification_channels/#update-notification-channel-by-id
+
+        :param id: notification channel id
+        :param channel: updated version of channel
+        :return: updated version of channel
+        """
         update_channel_by_id_path = "/alert-notifications/%s" % id
         return self.api.PUT(update_channel_by_id_path, json=channel)
 
     def delete_notification_by_uid(self, notification_uid):
-        delete_notification_by_uid_path = "alert-notifications/uid/%s" % notification_uid
+        """
+        https://grafana.com/docs/grafana/latest/http_api/alerting_notification_channels/#delete-alert-notification-by-uid
+
+        :param notification_uid: notification channel uid
+        :return: result of deletion
+        """
+        delete_notification_by_uid_path = (
+            "alert-notifications/uid/%s" % notification_uid
+        )
         return self.api.DELETE(delete_notification_by_uid_path)
 
     def delete_notification_by_id(self, notification_id):
+        """
+        https://grafana.com/docs/grafana/latest/http_api/alerting_notification_channels/#delete-alert-notification-by-uid
+
+        :param notification_id: notification channel id
+        :return: result of deletion
+        """
         delete_notification_by_id_path = "alert-notifications/uid/%s" % notification_id
         return self.api.DELETE(delete_notification_by_id_path)
-
-

--- a/grafana_api/api/notifications.py
+++ b/grafana_api/api/notifications.py
@@ -1,0 +1,45 @@
+from .base import Base
+
+
+class Notifications(Base):
+    def __init__(self, api):
+        super(Notifications, self).__init__(api)
+        self.api = api
+
+    def get_channels(self):
+        get_channels_path = "/alert-notifications"
+        return self.api.GET(get_channels_path)
+
+    def lookup_channels(self):
+        lookup_channels_path = "/alert-notifications/lookup"
+        return self.api.GET(lookup_channels_path)
+
+    def get_channel_by_uid(self, channel_uid):
+        get_channel_by_uid_path = "/alert-notifications/uid/%s" % channel_uid
+        return self.api.GET(get_channel_by_uid_path)
+
+    def get_channel_by_id(self, channel_id):
+        get_channel_by_id_path = "/alert-notifications/%s" % channel_id
+        return self.api.GET(get_channel_by_id_path)
+
+    def create_channel(self, channel):
+        create_channel_path = "/alert-notifications"
+        return self.api.POST(create_channel_path, json=channel)
+
+    def update_channel_by_uid(self, uid, channel):
+        update_channel_by_uid_path = "/alert-notifications/uid/%s" % uid
+        return self.api.PUT(update_channel_by_uid_path, json=channel)
+
+    def update_channel_by_id(self, id, channel):
+        update_channel_by_id_path = "/alert-notifications/%s" % id
+        return self.api.PUT(update_channel_by_id_path, json=channel)
+
+    def delete_notification_by_uid(self, notification_uid):
+        delete_notification_by_uid_path = "alert-notifications/uid/%s" % notification_uid
+        return self.api.DELETE(delete_notification_by_uid_path)
+
+    def delete_notification_by_id(self, notification_id):
+        delete_notification_by_id_path = "alert-notifications/uid/%s" % notification_id
+        return self.api.DELETE(delete_notification_by_id_path)
+
+

--- a/grafana_api/grafana_face.py
+++ b/grafana_api/grafana_face.py
@@ -12,6 +12,7 @@ from .api import (
     Teams,
     Snapshots,
     Annotations,
+    Notifications
 )
 
 
@@ -47,3 +48,4 @@ class GrafanaFace:
         self.teams = Teams(self.api)
         self.annotations = Annotations(self.api)
         self.snapshots = Snapshots(self.api)
+        self.notifications = Notifications(self.api)

--- a/test/api/test_notifications.py
+++ b/test/api/test_notifications.py
@@ -1,0 +1,293 @@
+import unittest
+
+import requests_mock
+
+from grafana_api.grafana_api import (
+    GrafanaBadInputError,
+    GrafanaClientError,
+    GrafanaServerError,
+    GrafanaUnauthorizedError,
+)
+from grafana_api.grafana_face import GrafanaFace
+
+
+class NotificationsTestCase(unittest.TestCase):
+    def setUp(self):
+        self.cli = GrafanaFace(
+            ("admin", "admin"), host="localhost", url_path_prefix="", protocol="http"
+        )
+
+    @requests_mock.Mocker()
+    def test_get_channels(self, mock):
+        mock.get(
+            "http://localhost/api/alert-notifications",
+            json=[
+                {
+                    "id": 1,
+                    "uid": "team-a-email-notifier",
+                    "name": "Team A",
+                    "type": "email",
+                    "isDefault": False,
+                    "sendReminder": False,
+                    "disableResolveMessage": False,
+                    "settings": {"addresses": "dev@grafana.com"},
+                    "created": "2018-04-23T14:44:09+02:00",
+                    "updated": "2018-08-20T15:47:49+02:00",
+                }
+            ],
+        )
+        notification_channels = self.cli.notifications.get_channels()
+        self.assertEqual(len(notification_channels), 1)
+
+        channel = notification_channels[0]
+        self.assertEqual(channel["id"], 1)
+        self.assertEqual(channel["uid"], "team-a-email-notifier")
+        self.assertEqual(channel["name"], "Team A")
+        self.assertEqual(channel["type"], "email")
+        self.assertFalse(channel["isDefault"])
+        self.assertFalse(channel["sendReminder"])
+        self.assertFalse(channel["disableResolveMessage"])
+        self.assertEqual(channel["settings"]["addresses"], "dev@grafana.com")
+        self.assertEqual(channel["created"], "2018-04-23T14:44:09+02:00")
+        self.assertEqual(channel["updated"], "2018-08-20T15:47:49+02:00")
+
+    @requests_mock.Mocker()
+    def test_lookup_channels(self, mock):
+        mock.get(
+            "http://localhost/api/alert-notifications/lookup",
+            json=[
+                {
+                    "id": 1,
+                    "uid": "000000001",
+                    "name": "Test",
+                    "type": "email",
+                    "isDefault": False,
+                },
+                {
+                    "id": 2,
+                    "uid": "000000002",
+                    "name": "Slack",
+                    "type": "slack",
+                    "isDefault": False,
+                },
+            ],
+        )
+        notification_channels = self.cli.notifications.lookup_channels()
+        self.assertEqual(len(notification_channels), 2)
+
+        channel_1 = notification_channels[0]
+        self.assertEqual(channel_1["id"], 1)
+        self.assertEqual(channel_1["uid"], "000000001")
+        self.assertEqual(channel_1["name"], "Test")
+        self.assertEqual(channel_1["type"], "email")
+        self.assertFalse(channel_1["isDefault"])
+
+        channel_2 = notification_channels[1]
+        self.assertEqual(channel_2["id"], 2)
+        self.assertEqual(channel_2["uid"], "000000002")
+        self.assertEqual(channel_2["name"], "Slack")
+        self.assertEqual(channel_2["type"], "slack")
+        self.assertFalse(channel_2["isDefault"])
+
+    @requests_mock.Mocker()
+    def test_get_channel_by_uid(self, mock):
+        mock.get(
+            "http://localhost/api/alert-notifications/uid/team-a-email-notifier",
+            json={
+                "id": 1,
+                "uid": "team-a-email-notifier",
+                "name": "Team A",
+                "type": "email",
+                "isDefault": False,
+                "sendReminder": False,
+                "disableResolveMessage": False,
+                "settings": {"addresses": "dev@grafana.com"},
+                "created": "2018-04-23T14:44:09+02:00",
+                "updated": "2018-08-20T15:47:49+02:00",
+            },
+        )
+
+        channel = self.cli.notifications.get_channel_by_uid("team-a-email-notifier")
+        self.assertEqual(channel["id"], 1)
+        self.assertEqual(channel["uid"], "team-a-email-notifier")
+        self.assertEqual(channel["name"], "Team A")
+        self.assertEqual(channel["type"], "email")
+        self.assertFalse(channel["isDefault"])
+        self.assertFalse(channel["sendReminder"])
+        self.assertFalse(channel["disableResolveMessage"])
+        self.assertEqual(channel["settings"]["addresses"], "dev@grafana.com")
+        self.assertEqual(channel["created"], "2018-04-23T14:44:09+02:00")
+        self.assertEqual(channel["updated"], "2018-08-20T15:47:49+02:00")
+
+    @requests_mock.Mocker()
+    def test_get_channel_by_id(self, mock):
+        mock.get(
+            "http://localhost/api/alert-notifications/1",
+            json={
+                "id": 1,
+                "uid": "team-a-email-notifier",
+                "name": "Team A",
+                "type": "email",
+                "isDefault": False,
+                "sendReminder": False,
+                "disableResolveMessage": False,
+                "settings": {"addresses": "dev@grafana.com"},
+                "created": "2018-04-23T14:44:09+02:00",
+                "updated": "2018-08-20T15:47:49+02:00",
+            },
+        )
+
+        channel = self.cli.notifications.get_channel_by_id(1)
+        self.assertEqual(channel["id"], 1)
+        self.assertEqual(channel["uid"], "team-a-email-notifier")
+        self.assertEqual(channel["name"], "Team A")
+        self.assertEqual(channel["type"], "email")
+        self.assertFalse(channel["isDefault"])
+        self.assertFalse(channel["sendReminder"])
+        self.assertFalse(channel["disableResolveMessage"])
+        self.assertEqual(channel["settings"]["addresses"], "dev@grafana.com")
+        self.assertEqual(channel["created"], "2018-04-23T14:44:09+02:00")
+        self.assertEqual(channel["updated"], "2018-08-20T15:47:49+02:00")
+
+    @requests_mock.Mocker()
+    def test_create_channel(self, mock):
+        mock.post(
+            "http://localhost/api/alert-notifications",
+            json={
+                "id": 2,
+                "uid": "new-alert-notification",
+                "name": "new alert notification",
+                "type": "email",
+                "isDefault": False,
+                "sendReminder": False,
+                "disableResolveMessage": False,
+                "settings": {"addresses": "dev@grafana.com"},
+                "created": "2018-04-23T14:44:09+02:00",
+                "updated": "2018-08-20T15:47:49+02:00",
+            },
+        )
+
+        payload = {
+            "uid": "new-alert-notification",
+            "name": "new alert notification",
+            "type": "email",
+            "isDefault": False,
+            "sendReminder": False,
+            "settings": {"addresses": "dev@grafana.com"},
+        }
+
+        created_channel = self.cli.notifications.create_channel(payload)
+        self.assertEqual(created_channel["id"], 2)
+        self.assertEqual(created_channel["uid"], "new-alert-notification")
+        self.assertEqual(created_channel["name"], "new alert notification")
+        self.assertEqual(created_channel["type"], "email")
+        self.assertFalse(created_channel["isDefault"])
+        self.assertFalse(created_channel["sendReminder"])
+        self.assertFalse(created_channel["disableResolveMessage"])
+        self.assertEqual(created_channel["settings"]["addresses"], "dev@grafana.com")
+        self.assertEqual(created_channel["created"], "2018-04-23T14:44:09+02:00")
+        self.assertEqual(created_channel["updated"], "2018-08-20T15:47:49+02:00")
+
+    @requests_mock.Mocker()
+    def test_update_channel_by_uid(self, mock):
+        mock.put(
+            "http://localhost/api/alert-notifications/uid/new-alert-notification",
+            json={
+                "id": 1,
+                "uid": "new-alert-notification",
+                "name": "new alert notification",
+                "type": "email",
+                "isDefault": False,
+                "sendReminder": True,
+                "frequency": "15m",
+                "settings": {"addresses": "dev@grafana.com"},
+                "created": "2017-01-01 12:34",
+                "updated": "2020-01-01 12:34",
+            },
+        )
+
+        payload = {
+            "uid": "new-alert-notification",
+            "name": "new alert notification",
+            "type": "email",
+            "isDefault": False,
+            "sendReminder": True,
+            "frequency": "15m",
+            "settings": {"addresses": "dev@grafana.com"},
+        }
+
+        updated_channel = self.cli.notifications.update_channel_by_uid("new-alert-notification", payload)
+        self.assertEqual(updated_channel["id"], 1)
+        self.assertEqual(updated_channel["uid"], "new-alert-notification")
+        self.assertEqual(updated_channel["name"], "new alert notification")
+        self.assertEqual(updated_channel["type"], "email")
+        self.assertFalse(updated_channel["isDefault"])
+        self.assertTrue(updated_channel["sendReminder"])
+        self.assertEqual(updated_channel["frequency"], "15m")
+        self.assertEqual(updated_channel["settings"]["addresses"], "dev@grafana.com")
+        self.assertEqual(updated_channel["created"], "2017-01-01 12:34")
+        self.assertEqual(updated_channel["updated"], "2020-01-01 12:34")
+
+    @requests_mock.Mocker()
+    def test_update_channel_by_id(self, mock):
+        mock.put(
+            "http://localhost/api/alert-notifications/1",
+            json={
+                "id": 1,
+                "uid": "new-alert-notification",
+                "name": "new alert notification",
+                "type": "email",
+                "isDefault": False,
+                "sendReminder": True,
+                "frequency": "15m",
+                "settings": {"addresses": "dev@grafana.com"},
+                "created": "2017-01-01 12:34",
+                "updated": "2020-01-01 12:34",
+            },
+        )
+
+        payload = {
+            "uid": "new-alert-notification",
+            "name": "new alert notification",
+            "type": "email",
+            "isDefault": False,
+            "sendReminder": True,
+            "frequency": "15m",
+            "settings": {"addresses": "dev@grafana.com"},
+        }
+
+        updated_channel = self.cli.notifications.update_channel_by_id(1, payload)
+        self.assertEqual(updated_channel["id"], 1)
+        self.assertEqual(updated_channel["uid"], "new-alert-notification")
+        self.assertEqual(updated_channel["name"], "new alert notification")
+        self.assertEqual(updated_channel["type"], "email")
+        self.assertFalse(updated_channel["isDefault"])
+        self.assertTrue(updated_channel["sendReminder"])
+        self.assertEqual(updated_channel["frequency"], "15m")
+        self.assertEqual(updated_channel["settings"]["addresses"], "dev@grafana.com")
+        self.assertEqual(updated_channel["created"], "2017-01-01 12:34")
+        self.assertEqual(updated_channel["updated"], "2020-01-01 12:34")
+
+    @requests_mock.Mocker()
+    def test_delete_notification_by_uid(self, mock):
+        mock.delete(
+            "http://localhost/api/alert-notifications/uid/new-alert-notification",
+            json={
+                "message": "Notification deleted"
+            },
+        )
+
+        delete_response = self.cli.notifications.delete_notification_by_uid("new-alert-notification")
+        self.assertEqual(delete_response["message"], "Notification deleted")
+
+    @requests_mock.Mocker()
+    def test_delete_notification_by_id(self, mock):
+        mock.delete(
+            "http://localhost/api/alert-notifications/1",
+            json={
+                "message": "Notification deleted"
+            },
+        )
+
+        delete_response = self.cli.notifications.delete_notification_by_id(1)
+        self.assertEqual(delete_response["message"], "Notification deleted")


### PR DESCRIPTION
# Pull Request Template

## Description
Added support for [notification channels](https://grafana.com/docs/grafana/latest/http_api/alerting_notification_channels/), as was requested by me in [this issue](https://github.com/m0nhawk/grafana_api/issues/64).

## Have you written tests?

- [X] Yes
- [ ] No

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
