### PR TITLE
Fixed a bug in grafana.users.search_user api

### DIFF
--- a/grafana_api/api/user.py
+++ b/grafana_api/api/user.py
@@ -34,8 +34,10 @@ class Users(Base):
         show_users_path += "&".join(params)
 
         if iterate:
-            while users_on_page is not []:
+            while True:
                 users_on_page = self.api.GET(show_users_path % page)
+                if not users_on_page:
+                    break
                 list_of_users += users_on_page
                 page += 1
         else:


### PR DESCRIPTION
<!-- Change a name for Pull Request -->
# Fixed a bug in grafana.users.search_user api

## Description
<!-- Please include a summary of the change or which issue is fixed (fixes #(issue)). -->
search_user api is resulting in infinite loop. It might be due to response object comparison with empty list. Empty list reference might not be same as response object reference even though both are empty lists.

So, I added an "if condition" after getting response from user api along the lines of grafana.teams.search_teams api

## Have you written tests?

- [ ] Yes
- [x] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
