### PR TITLE
Fix: Get annotation URI params

### DIFF
--- a/grafana_api/api/annotations.py
+++ b/grafana_api/api/annotations.py
@@ -37,10 +37,10 @@ class Annotations(Base):
         params = []
 
         if time_from:
-            params.append("time_from=%s" % time_from)
+            params.append("from=%s" % time_from)
 
         if time_to:
-            params.append("time_to=%s" % time_to)
+            params.append("to=%s" % time_to)
 
         if alert_id:
             params.append("alertId=%s" % alert_id)


### PR DESCRIPTION
Get Annotations params
# Pull Request Template

## Description
Small fix for get annotations param name

## Have you written tests?

- [ ] Yes
- [X] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
