### PR TITLE
fix a small bug

### DIFF
--- a/grafana_api/api/team.py
+++ b/grafana_api/api/team.py
@@ -36,7 +36,7 @@ class Teams(Base):
             while True:
                 teams_on_page = self.api.GET(search_teams_path % page)
                 list_of_teams += teams_on_page["teams"]
-                if len(list_of_teams) == teams_on_page["totalCount"]:
+                if len(teams_on_page["teams"]) < teams_on_page["perPage"]:
                     break
                 page += 1
         else:


### PR DESCRIPTION
I encountered a situation where the value of "totalCount" was inconsistent with the total length of "team", which resulted in a loop that could not be returned.
So I modified the break condition and solved the problem.

Sorry, my English is not good, this is done with Google Translate, I hope my expression and translation are very clear