### PR TITLE
Allow Dependency to Download from Setup.py File

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,4 +7,5 @@ setup(
         "version_scheme": "python-simplified-semver",
         "write_to": "grafana_api/version.py",
     },
+    install_requires=['requests'],
 )

--- a/setup.py
+++ b/setup.py
@@ -7,5 +7,6 @@ setup(
         "version_scheme": "python-simplified-semver",
         "write_to": "grafana_api/version.py",
     },
+    # For all dependent libraries
     install_requires=['requests'],
 )


### PR DESCRIPTION
Allow Dependency to Download from Setup.py File
# Pull Request Template

## Description
This will allow the dependent requests library to install upon installation from of the module from pypi/pip, so there is no need to install it separately. Minor change in the setup file.

## Have you written tests?

- [ ] Yes
- [ x ] No

## Checklist:

- [ x ] My code follows the style guidelines of this project
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ x ] I have made corresponding changes to the documentation
- [ x ] My changes generate no new warnings
